### PR TITLE
TST: zeroish-length waveform char array

### DIFF
--- a/simulator.py
+++ b/simulator.py
@@ -47,6 +47,7 @@ str_waves = make_pvs("string128", "string2k", "string64k")
 
 subarrays =  make_pvs("subArr1", "subArr2", "subArr3", "subArr4" )
 subarray_driver = make_pvs("wave_test",)[0]
+emptyish_string_wave = make_pvs("waveform_char256",)[0]
 
 
 def initialize_data():
@@ -54,6 +55,9 @@ def initialize_data():
 
     for p in mbbos:
         p.put(1)
+
+    # the 'empty-ish' string has a NORD of 1, with its value being "\0"
+    emptyish_string_wave.put([0])
 
     for i, p in enumerate(longs):    p.put((i+1))
 

--- a/testiocApp/Db/pydebug.db
+++ b/testiocApp/Db/pydebug.db
@@ -59,6 +59,12 @@ record(waveform,"$(P)char64k")  {
        field(FTVL,"UCHAR")
 }
 
+record(waveform, "$(P)waveform_char256")
+{
+    field(FTVL, "CHAR")
+    field(NELM, "256")
+}
+
 record(waveform,"$(P)double128")  {
        field(DTYP,"Soft Channel")
        field(DESC,"short double waveform")


### PR DESCRIPTION
The 'empty-ish' string has a NORD of 1, with its value being "\0", which was not being tested previously
